### PR TITLE
Add reproducible docker run scripts

### DIFF
--- a/docker/myrun/Dockerfile
+++ b/docker/myrun/Dockerfile
@@ -1,0 +1,16 @@
+# Build Agent Zero runtime image from the latest repository sources
+FROM frdel/agent-zero-base:latest
+
+WORKDIR /a0
+
+# Copy repository into the image
+COPY . /a0
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Expose default web UI port
+EXPOSE 80
+
+# Run the default startup script
+CMD ["/exe/run_A0.sh", "main"]

--- a/docker/myrun/Makefile
+++ b/docker/myrun/Makefile
@@ -1,0 +1,18 @@
+IMAGE=agent-zero-run:local
+CONTAINER=agent-zero
+DATA_DIR=/mypool/agent-zero-data
+PORT=50080
+
+build:
+	docker build -f docker/myrun/Dockerfile -t $(IMAGE) .
+
+run: build
+	docker run --gpus all --name $(CONTAINER) -p $(PORT):80 -v $(DATA_DIR):/a0 $(IMAGE) $(ARGS)
+
+compose-up:
+	docker-compose -f docker/myrun/docker-compose.yml up
+
+compose-down:
+	docker-compose -f docker/myrun/docker-compose.yml down
+
+.PHONY: build run compose-up compose-down

--- a/docker/myrun/docker-compose.yml
+++ b/docker/myrun/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  agent-zero:
+    build:
+      context: ../..
+      dockerfile: docker/myrun/Dockerfile
+    image: agent-zero-run:local
+    container_name: agent-zero
+    ports:
+      - "50080:80"
+    volumes:
+      - /mypool/agent-zero-data:/a0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]


### PR DESCRIPTION
## Summary
- add `Dockerfile`, `Makefile` and `docker-compose.yml` under `docker/myrun`
- `Dockerfile` builds runtime image using current repo sources
- `Makefile` provides build/run/compose helpers
- docker-compose config to run container with GPU support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b23627e08332be7d26317300a168