### PR TITLE
Add retry patch without altering source

### DIFF
--- a/docker/myrun/Dockerfile
+++ b/docker/myrun/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # --- Copy the Agent-Zero Source ---
 # Copy runtime files to /a0 so /a0/ins and /a0/exe are available
 COPY ./fs/ /
+COPY ./patches/ /patches/
 
 RUN mkdir /opt
 RUN python -m venv /opt/venv
@@ -24,6 +25,9 @@ RUN python -m venv /opt/venv
 RUN chmod +x /ins/*.sh /exe/*.sh && \
     bash /ins/pre_install.sh "$BRANCH" && \
     bash /ins/install_A0.sh "$BRANCH" && \
+    for p in /patches/*.patch; do \
+        patch -d /git/agent-zero -p1 < "$p"; \
+    done && \
     bash /ins/install_additional.sh "$BRANCH"
 
 # --- Cache Busting Build Layer ---

--- a/docker/myrun/patches/agent_retry.patch
+++ b/docker/myrun/patches/agent_retry.patch
@@ -1,0 +1,39 @@
+--- a/agent.py
++++ b/agent.py
+@@
+-import asyncio
+-import nest_asyncio
++import asyncio
++import httpx
++import nest_asyncio
+@@
+-        async for chunk in (prompt | model).astream({}):
+-            await self.handle_intervention()
+-            content = models.parse_chunk(chunk)
+-            limiter.add(output=tokens.approximate_tokens(content))
+-            response += content
+-            if callback:
+-                await callback(content, response)
++        attempt = 0
++        while True:
++            try:
++                async for chunk in (prompt | model).astream({}):
++                    await self.handle_intervention()
++                    content = models.parse_chunk(chunk)
++                    limiter.add(output=tokens.approximate_tokens(content))
++                    response += content
++                    if callback:
++                        await callback(content, response)
++                break
++            except httpx.ReadError as exc:
++                attempt += 1
++                self.context.log.log(
++                    type="warning",
++                    heading="stream interrupted",
++                    content=str(exc),
++                )
++                if attempt >= 3:
++                    raise
++                await asyncio.sleep(1)
++                response = ""
+         return response


### PR DESCRIPTION
## Summary
- include a patch file that adds retry logic around streaming `ReadError`
- apply patches during Docker build via `docker/myrun/Dockerfile`
- reverted direct source modifications so repository code is untouched

## Testing
- `python -m py_compile agent.py`
- `make -C docker/myrun build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685792187e808332bffcda76d0cdd468