### PR TITLE
Add patch instructions

### DIFF
--- a/docker/myrun/AGENTS.md
+++ b/docker/myrun/AGENTS.md
@@ -1,0 +1,1 @@
+When making changes to this repository, **do not modify the original source tree**. All modifications must be delivered as patch files or additional assets within this directory. Place any patch files in `docker/myrun/patches` so they can be applied during the build process. Do not change files outside `docker/myrun`.

--- a/docker/myrun/patches/agent_retry.patch
+++ b/docker/myrun/patches/agent_retry.patch
@@ -25,7 +25,7 @@
 +                    if callback:
 +                        await callback(content, response)
 +                break
-+            except httpx.ReadError as exc:
++            except httpx.HTTPError as exc:
 +                attempt += 1
 +                self.context.log.log(
 +                    type="warning",


### PR DESCRIPTION
## Summary
- ensure OpenAI streaming retries on any HTTP error via patch
- document patch-only workflow in `docker/myrun`

## Testing
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6857976332fc8332adaf5106f78deb47