### PR TITLE
Improve Docker caching workflow

### DIFF
--- a/docker/myrun/.dockerignore
+++ b/docker/myrun/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore VCS
+.git
+.gitignore
+
+# Python caches and build artifacts
+**/__pycache__/
+**/*.pyc
+build/
+dist/
+
+# Temporary and data directories
+logs/
+tmp/
+memory/
+
+# IDE and misc
+.vscode/
+.DS_Store
+
+# Bundled or test assets
+bundle/
+work_dir/
+*.test.py

--- a/docker/myrun/Dockerfile
+++ b/docker/myrun/Dockerfile
@@ -2,16 +2,17 @@ FROM python:3.12-slim
 
 # --- Metadata ---
 ARG BRANCH
+ARG CACHE_DATE=none
 ENV BRANCH=${BRANCH:-main}
-####WORKDIR /a0
 
 # --- System Dependencies ---
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         bash curl git build-essential nano \
         openssh-server supervisor \
-        python3-venv libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libasound2 \
-        && apt-get clean && rm -rf /var/lib/apt/lists/*
+        python3-venv libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libasound2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the searxng user required by supervisord
 RUN useradd --system --create-home \
@@ -28,26 +29,32 @@ RUN curl -Ls https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
 COPY ./fs/ /
 COPY ./patches/ /patches/
 
-RUN mkdir -p /opt
-RUN python -m venv /opt/venv
+RUN mkdir -p /opt \
+    && python -m venv /opt/venv
 
-RUN apt-get update && apt-get upgrade -y
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get upgrade -y
 # --- Installation Scripts (Agent-Zero) ---
-RUN chmod +x /ins/*.sh /exe/*.sh 
-RUN bash /ins/pre_install.sh "$BRANCH" 
-RUN bash /ins/install_A0.sh "$BRANCH" && \
-    for p in /patches/*.patch; do \
-        patch -d /git/agent-zero -p1 < "$p"; \
-    done 
-RUN bash /ins/install_additional.sh "$BRANCH"
-RUN apt-get update && apt-get upgrade -y
+RUN chmod +x /ins/*.sh /exe/*.sh
+RUN --mount=type=cache,target=/root/.cache \
+    bash /ins/pre_install.sh "$BRANCH"
+RUN --mount=type=cache,target=/root/.cache \
+    bash /ins/install_A0.sh "$BRANCH" && \
+        for p in /patches/*.patch; do \
+            patch -d /git/agent-zero -p1 < "$p"; \
+        done
+RUN --mount=type=cache,target=/root/.cache \
+    bash /ins/install_additional.sh "$BRANCH"
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get upgrade -y
 
 # --- Cache Busting Build Layer ---
-ARG CACHE_DATE=none
-RUN echo "cache bust $CACHE_DATE" && bash /ins/install_A02.sh "$BRANCH"
+RUN --mount=type=cache,target=/root/.cache \
+    echo "cache bust $CACHE_DATE" && bash /ins/install_A02.sh "$BRANCH"
 
 # --- Finalize ---
-RUN bash /ins/post_install.sh "$BRANCH"
+RUN --mount=type=cache,target=/root/.cache \
+    bash /ins/post_install.sh "$BRANCH"
 
 # --- Executables ---
 RUN chmod +x /exe/initialize.sh /exe/run_A0.sh /exe/run_searxng.sh /exe/run_tunnel_api.sh

--- a/docker/myrun/Makefile
+++ b/docker/myrun/Makefile
@@ -3,10 +3,17 @@ CONTAINER=agent-zero
 DATA_DIR=/mypool/agent-zero-data
 PORT=50080
 
+CACHE_DATE ?= $(shell date +%Y-%m-%d:%H:%M:%S)
+
 build: clean
 	rm -rf ./fs
 	cp -R ../run/fs .
-	docker build -t agent-zero-run:local --build-arg BRANCH=development --no-cache  .
+	docker build -t $(IMAGE) --build-arg BRANCH=development --build-arg CACHE_DATE=$(CACHE_DATE) .
+
+rebuild: clean
+	rm -rf ./fs
+	cp -R ../run/fs .
+	docker build --no-cache -t $(IMAGE) --build-arg BRANCH=development --build-arg CACHE_DATE=$(shell date +%Y-%m-%d:%H:%M:%S) .
 
 run: build
 	docker run --gpus all --name $(CONTAINER) -p $(PORT):80 -v $(DATA_DIR):/a0 $(IMAGE) $(ARGS)

--- a/docker/myrun/cuda_reuse.md
+++ b/docker/myrun/cuda_reuse.md
@@ -1,0 +1,7 @@
+# CUDA/Torch Environment Reuse
+
+- Build a base image with CUDA, cuDNN and Torch installed and tag it (e.g., `a0-cuda:base`).
+- Use that base image in your Dockerfile `FROM` line so layers with heavy binaries do not change.
+- When updating your application code, avoid rebuilding the CUDA layer unless versions change.
+- Mount persistent pip/apt caches with BuildKit (`--mount=type=cache,target=/root/.cache` and `/var/cache/apt`) to speed up installs.
+- Keep CUDA libraries in a separate image so multiple projects can reference the same base without duplication.

--- a/docker/myrun/docker_clean.sh
+++ b/docker/myrun/docker_clean.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clean unused Docker data and optionally older images/containers
+set -e
+
+DAYS=${1:-0}
+
+if [ "$DAYS" -gt 0 ]; then
+    HOURS=$((DAYS*24))
+    docker container prune -f --filter "until=${HOURS}h"
+    docker image prune -f --filter "until=${HOURS}h"
+fi
+
+docker system prune -a --volumes -f
+


### PR DESCRIPTION
## Summary
- optimize Dockerfile with caching mounts and manual cache busting
- ignore temp files via `.dockerignore`
- add cleanup script for Docker resources
- update Makefile to enable cached builds and add `rebuild` target
- document reuse of CUDA/Torch environments

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857a52837e083329ad009d1de5872b8