### PR TITLE
Remove patch; fix Makefile indentation

### DIFF
--- a/docker/myrun/Makefile
+++ b/docker/myrun/Makefile
@@ -6,24 +6,24 @@ PORT=50080
 CACHE_DATE ?= $(shell date +%Y-%m-%d:%H:%M:%S)
 
 build: clean
-        rm -rf ./fs
-        cp -R ../run/fs .
-        docker compose -f docker-compose.yml build \
-            --build-arg BRANCH=development \
-            --build-arg CACHE_DATE=$(CACHE_DATE)
+	rm -rf ./fs
+	cp -R ../run/fs .
+	docker compose -f docker-compose.yml build \
+	    --build-arg BRANCH=development \
+	    --build-arg CACHE_DATE=$(CACHE_DATE)
 
 rebuild: clean
-        rm -rf ./fs
-        cp -R ../run/fs .
-        docker compose -f docker-compose.yml build --no-cache \
-            --build-arg BRANCH=development \
-            --build-arg CACHE_DATE=$(shell date +%Y-%m-%d:%H:%M:%S)
+	rm -rf ./fs
+	cp -R ../run/fs .
+	docker compose -f docker-compose.yml build --no-cache \
+	    --build-arg BRANCH=development \
+	    --build-arg CACHE_DATE=$(shell date +%Y-%m-%d:%H:%M:%S)
 
 run: build
-        docker compose -f docker-compose.yml up -d
+	docker compose -f docker-compose.yml up -d
 
 up:
-        docker compose -f docker-compose.yml up -d
+	docker compose -f docker-compose.yml up -d
 
 down:
 	docker compose -f docker-compose.yml down


### PR DESCRIPTION
## Summary
- fix `docker/myrun/Makefile` by using tab-indented command lines
- remove outdated `fix_makefile_tabs.patch`

## Testing
- `make -C docker/myrun -n build`


------
https://chatgpt.com/codex/tasks/task_e_6857ac4355cc8332b0004071360a00ae