### PR TITLE
Fix persistent MCP client patch format

### DIFF
--- a/docker/myrun/patches/persistent_mcp_client.patch
+++ b/docker/myrun/patches/persistent_mcp_client.patch
@@ -1,37 +1,45 @@
 --- a/python/helpers/mcp_handler.py
 +++ b/python/helpers/mcp_handler.py
-@@
- class MCPClientBase(ABC):
-@@
--    def __init__(self, server: Union[MCPServerLocal, MCPServerRemote]):
--        self.server = server
--        self.tools: List[dict[str, Any]] = []  # Tools are cached on the client instance
--        self.error: str = ""
--        self.log: List[str] = []
--        self.log_file: Optional[TextIO] = None
-+    def __init__(self, server: Union[MCPServerLocal, MCPServerRemote]):
-+        self.server = server
-+        self.tools: List[dict[str, Any]] = []  # Tools are cached on the client instance
-+        self.error: str = ""
-+        self.log: List[str] = []
-+        self.log_file: Optional[TextIO] = None
+@@ -816,6 +816,8 @@
+         self.error: str = ""
+         self.log: List[str] = []
+         self.log_file: Optional[TextIO] = None
 +        self._exit_stack: Optional[AsyncExitStack] = None
 +        self._session: Optional[ClientSession] = None
-@@
--    async def _execute_with_session(
--        self,
--        coro_func: Callable[[ClientSession], Awaitable[T]],
--        read_timeout_seconds=60,
--    ) -> T:
--        """
--        Manages the lifecycle of an MCP session for a single operation.
--        Creates a temporary session, executes coro_func with it, and ensures cleanup.
--        """
+ 
+     # Protected method
+     @abstractmethod
+@@ -827,6 +829,20 @@
+     ]:
+         """Create stdio/write streams using the provided exit_stack."""
+         ...
++    async def _ensure_session(self, read_timeout_seconds: int) -> ClientSession:
++        if self._session is None:
++            self._exit_stack = AsyncExitStack()
++            stdio, write = await self._create_stdio_transport(self._exit_stack)
++            self._session = await self._exit_stack.enter_async_context(
++                ClientSession(
++                    stdio,  # type: ignore
++                    write,  # type: ignore
++                    read_timeout_seconds=timedelta(seconds=read_timeout_seconds),
++                )
++            )
++            await self._session.initialize()
++        return self._session
++
+ 
+     async def _execute_with_session(
+         self,
+@@ -837,59 +853,24 @@
+         Manages the lifecycle of an MCP session for a single operation.
+         Creates a temporary session, executes coro_func with it, and ensures cleanup.
+         """
 -        operation_name = coro_func.__name__  # For logging
 -        # PrintStyle(font_color="cyan").print(f"MCPClientBase ({self.server.name}): Creating new session for operation '{operation_name}'...")
 -        # Store the original exception outside the async block
 -        original_exception = None
--        try:
++        operation_name = coro_func.__name__
+         try:
 -            async with AsyncExitStack() as temp_stack:
 -                try:
 -
@@ -60,16 +68,18 @@
 -                        original_exception = e
 -                    # Create a dummy exception to break out of the async block
 -                    raise RuntimeError("Dummy exception to break out of async block")
--        except Exception as e:
++            session = await self._ensure_session(read_timeout_seconds)
++            return await coro_func(session)
+         except Exception as e:
 -            # Check if this is our dummy exception
 -            if original_exception is not None:
 -                e = original_exception
 -            # We have the original exception stored
--            PrintStyle(
--                background_color="#AA4455", font_color="white", padding=False
--            ).print(
--                f"MCPClientBase ({self.server.name} - {operation_name}): Error during operation: {type(e).__name__}: {e}"
--            )
+             PrintStyle(
+                 background_color="#AA4455", font_color="white", padding=False
+             ).print(
+                 f"MCPClientBase ({self.server.name} - {operation_name}): Error during operation: {type(e).__name__}: {e}"
+             )
 -            raise e  # Re-raise the original exception
 -        # finally:
 -        #     PrintStyle(font_color="cyan").print(
@@ -80,41 +90,14 @@
 -        raise RuntimeError(
 -            f"MCPClientBase ({self.server.name} - {operation_name}): _execute_with_session exited 'async with' block unexpectedly."
 -        )
-+    async def _ensure_session(self, read_timeout_seconds: int) -> ClientSession:
-+        if self._session is None:
-+            self._exit_stack = AsyncExitStack()
-+            stdio, write = await self._create_stdio_transport(self._exit_stack)
-+            self._session = await self._exit_stack.enter_async_context(
-+                ClientSession(
-+                    stdio,  # type: ignore
-+                    write,  # type: ignore
-+                    read_timeout_seconds=timedelta(seconds=read_timeout_seconds),
-+                )
-+            )
-+            await self._session.initialize()
-+        return self._session
-+
-+    async def _execute_with_session(
-+        self,
-+        coro_func: Callable[[ClientSession], Awaitable[T]],
-+        read_timeout_seconds=60,
-+    ) -> T:
-+        operation_name = coro_func.__name__
-+        try:
-+            session = await self._ensure_session(read_timeout_seconds)
-+            return await coro_func(session)
-+        except Exception as e:
-+            PrintStyle(
-+                background_color="#AA4455", font_color="white", padding=False
-+            ).print(
-+                f"MCPClientBase ({self.server.name} - {operation_name}): Error during operation: {type(e).__name__}: {e}"
-+            )
 +            await self.aclose()
 +            raise
-+
 +    async def aclose(self) -> None:
 +        if self._exit_stack is not None:
 +            await self._exit_stack.aclose()
 +            self._exit_stack = None
 +            self._session = None
-
++
+ 
+     async def update_tools(self) -> "MCPClientBase":
+         # PrintStyle(font_color="cyan").print(f"MCPClientBase ({self.server.name}): Starting 'update_tools' operation...")


### PR DESCRIPTION
## Summary
- replace `persistent_mcp_client.patch` with a valid unified diff
- patch adds persistent session management

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ac84229248332a052a3a7ea5b5936